### PR TITLE
Updating translate task -sourcepath

### DIFF
--- a/j2obc.gradle
+++ b/j2obc.gradle
@@ -272,7 +272,7 @@ class J2objcTranslateTask extends DefaultTask {
                 args firstArgs.split()
 
                 args "-d", "${destDir}"
-                args "-sourcepath", project.file("src/main/java").path
+                args "-sourcepath", "${project.file("src/main/java").path}:${project.file("src/test/java").path}"
 
                 project.j2objcConfig.translateJ2objcLibs.each { library ->
                     def libPath = J2objcUtils.j2objcHome(getProject()) + "/lib/" + library


### PR DESCRIPTION
if you define custom matchers in your test tree that depend on a  tip in your source tree then the j2obcTranslate task would fail because only the source tree was set as the -sourcepath for the j2objc script (even though all java files are passed to it.)  this change updates the -sourcepath according to the j2objc documentation to be "source_tree:test_tree"