### PR TITLE
Added new configuration property buildSourceDir

### DIFF
--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -83,8 +83,8 @@ class J2objcPluginExtension {
     // Where to copy generated files (excludes test code and executable)
     String destDir = null
 
-	// Additional sources that should be included on the classpath, e.g., java annotation processor source files
-	String buildSourceDir = null 
+    // Additional sources that should be included on the classpath, e.g., java annotation processor source files
+    String buildSourceDir = null 
 
     // Path to j2objc distribution
     String j2objcHome = null
@@ -320,12 +320,12 @@ class J2objcTranslateTask extends DefaultTask {
         println "Deleting j2objc build dir: " + destDir.path
         project.delete destDir.path
 
-		def buildSourceDir = project.j2objcConfig.buildSourceDir
-		println "buildSourceDir: "+buildSourceDir		
-		if (buildSourceDir) {
-			def buildSrcFiles = project.files(project.fileTree(dir: buildSourceDir, includes: ["**/*.java"]))
-			srcFiles += buildSrcFiles
-		}
+	def buildSourceDir = project.j2objcConfig.buildSourceDir
+	println "buildSourceDir: "+buildSourceDir		
+	if (buildSourceDir) {
+		def buildSrcFiles = project.files(project.fileTree(dir: buildSourceDir, includes: ["**/*.java"]))
+		srcFiles += buildSrcFiles
+	}
 
         srcFiles = J2objcUtils.fileFilter(srcFiles,
                 project.j2objcConfig.translateIncludeRegex,

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -83,7 +83,8 @@ class J2objcPluginExtension {
     // Where to copy generated files (excludes test code and executable)
     String destDir = null
 
-    // Additional sources that should be included on the classpath, e.g., java annotation processor source files
+    // Only generated source files, e.g. from dagger annotations. The script will
+    // ignore changes in this directory so they must be limited to generated files.
     String generatedSourceDir = null 
     
     // Path to j2objc distribution

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -83,6 +83,9 @@ class J2objcPluginExtension {
     // Where to copy generated files (excludes test code and executable)
     String destDir = null
 
+	// Additional sources that should be included on the classpath, e.g., java annotation processor source files
+	String buildSourceDir = null 
+
     // Path to j2objc distribution
     String j2objcHome = null
 
@@ -316,6 +319,13 @@ class J2objcTranslateTask extends DefaultTask {
         // Print command before operation to be helpful log if operation fails
         println "Deleting j2objc build dir: " + destDir.path
         project.delete destDir.path
+
+		def buildSourceDir = project.j2objcConfig.buildSourceDir
+		println "buildSourceDir: "+buildSourceDir		
+		if (buildSourceDir) {
+			def buildSrcFiles = project.files(project.fileTree(dir: buildSourceDir, includes: ["**/*.java"]))
+			srcFiles += buildSrcFiles
+		}
 
         srcFiles = J2objcUtils.fileFilter(srcFiles,
                 project.j2objcConfig.translateIncludeRegex,

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -84,8 +84,8 @@ class J2objcPluginExtension {
     String destDir = null
 
     // Additional sources that should be included on the classpath, e.g., java annotation processor source files
-    String buildSourceDir = null 
-
+    String generatedSourceDir = null 
+    
     // Path to j2objc distribution
     String j2objcHome = null
 
@@ -320,10 +320,10 @@ class J2objcTranslateTask extends DefaultTask {
         println "Deleting j2objc build dir: " + destDir.path
         project.delete destDir.path
 
-	def buildSourceDir = project.j2objcConfig.buildSourceDir
-	println "buildSourceDir: "+buildSourceDir		
-	if (buildSourceDir) {
-		def buildSrcFiles = project.files(project.fileTree(dir: buildSourceDir, includes: ["**/*.java"]))
+	def generatedSourceDir = project.j2objcConfig.generatedSourceDir
+	println "generatedSourceDir: "+generatedSourceDir		
+	if (generatedSourceDir) {
+		def buildSrcFiles = project.files(project.fileTree(dir: generatedSourceDir, includes: ["**/*.java"]))
 		srcFiles += buildSrcFiles
 	}
 


### PR DESCRIPTION
When you use java annotation processing like in Dagger2 you need to specify where the additional generated source is located. 

Using ``buildSourceDir`` in your config lets you define it.

There one problem you might be able to solve quickly. When doing ``gradle j2objcTranslate`` the second time it only restarts the task if sources in ``src/mani/java``have been change. My buildSourceDir is: 

```
buildSourceDir "${projectDir}/build/source/apt"
```

The translation task is not done a second time if files have changed. Could you fix that?