### PR TITLE
Generate universal static libraries for iphone and simulator.

### DIFF
--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -136,6 +136,10 @@ class J2objcPluginExtension {
     String testIncludeRegex = null
     // Warn if no tests are executed
     boolean testExecutedCheck = true
+
+    // Define static archive name for j2objcLink
+    String staticLibName = "library.a"
+    String distributionDir = null
 }
 
 
@@ -417,6 +421,121 @@ class J2objcTranslateTask extends DefaultTask {
     }
 }
 
+// TODO: Add better error handling
+// TODO: Remove dependency of sysroot_path.sh script.
+// TODO: compileFlags must be set to blank "", we get linker errors otherwise?
+// TODO: Document this feature.
+class J2objcLinkTask extends DefaultTask {
+    @InputDirectory File srcDir
+    @OutputDirectory File destDir
+
+    @TaskAction
+    def link() {
+        def flagMap = [:]
+        def output = new ByteArrayOutputStream()
+        def sysroot= ""
+        def script = project.file("scripts/sysroot_path.sh").path
+
+        // Add iphone build flags
+        project.exec {
+            executable script
+            args "--iphoneos"
+            standardOutput = output
+        }
+        sysroot = output.toString()
+        flagMap['armv7'] = "-arch armv7 -miphoneos-version-min=5.0 -isysroot ${sysroot}"
+        flagMap['arm64'] = "-arch arm64 -miphoneos-version-min=5.0 -isysroot ${sysroot}"
+        flagMap['armv7s'] = "-arch armv7s -miphoneos-version-min=5.0 -isysroot ${sysroot}"
+
+        // Add iphone sumulator build flags
+        output = new ByteArrayOutputStream()
+        project.exec {
+            executable script
+            args "--iphonesimulator"
+            standardOutput = output
+        }
+        sysroot = output.toString()
+        flagMap['i386'] = "-arch i386 -miphoneos-version-min=5.0 -isysroot ${sysroot}"
+
+        // Compile all platforms
+        def binary = J2objcUtils.j2objcHome(getProject()) + "/j2objcc"
+        for (arch in flagMap.keySet()) {
+            println "Building ${arch} object files."
+            def archDir = new File(destDir, arch)
+            if (!archDir.exists()) {
+                archDir.mkdirs()
+            }
+
+            project.exec {
+                workingDir "${archDir.path}"
+                executable binary
+                args "-I${srcDir}"
+                args "-c"
+
+                args flagMap[arch]
+                args "${project.j2objcConfig.compileFlags}".split()
+
+                def srcFiles = project.files(project.fileTree(
+                    dir: srcDir, includes: ["**/*.mm",  "**/*.m"]))
+                srcFiles.each { file ->
+                    args file.path
+                }
+            }
+
+            // Create arch specific archives 
+            println "Building ${arch} archive."           
+            project.exec {
+                workingDir "${archDir.path}"
+                commandLine "ar"
+                args  "rcs"
+                args  "${project.j2objcConfig.staticLibName}"
+
+                def srcFiles = project.files(project.fileTree(
+                    dir: archDir, includes: ["**/*.o"]))
+                srcFiles.each { file ->
+                    args file.path
+                }
+            }
+        }
+
+        def distDir = new File("${project.j2objcConfig.distributionDir}")
+        def includeDir = new File(distDir, "include")
+        def libDir = new File(distDir, "lib")
+        if (!includeDir.exists()) {
+            includeDir.mkdirs()
+        }
+        if (!libDir.exists()) {
+            libDir.mkdirs()
+        }
+
+        println "Copying header files to ${includeDir.path}"
+        project.copy {
+            includeEmptyDirs = false
+            from destDir
+            into includeDir
+            include "**/*.h"
+        }
+
+        println "Merging Universal archive to ${libDir.path}"   
+        project.exec {
+            workingDir "${libDir.path}"
+            commandLine "lipo"
+            args "-create"
+
+            for (arch in flagMap.keySet()) {
+                def archDir = new File(destDir, arch)
+                def archLib = new File(archDir, "${project.j2objcConfig.staticLibName}" )
+                if (archLib.exists()) {
+                    args "${archLib.path}"
+                }                
+            }
+
+            args "-output"
+            args "${project.j2objcConfig.staticLibName}"
+        }
+    }
+}
+
 
 class J2objcCompileTask extends DefaultTask {
 
@@ -621,6 +740,13 @@ class j2objc implements Plugin<Project> {
                 description "Compiles the j2objc generated Objective-C code to 'testrunner' binary"
                 srcDir = file("${buildDir}/j2objc")
                 destFile = file("${buildDir}/j2objc/testrunner")
+            }
+
+            project.tasks.create(name: "j2objcLink", type: J2objcLinkTask,
+                    dependsOn: 'j2objcTranslate') {
+                description "Compiles and Links the j2objc generated Objective-C code to a static library"
+                srcDir = file("${buildDir}/j2objc")
+                destDir = file("${buildDir}/j2objc")
             }
 
             project.tasks.create(name: "j2objcTest", type: J2objcTestTask,

--- a/scripts/sysroot_path.sh
+++ b/scripts/sysroot_path.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright 2012 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Returns the location of the latest installed Xcode Mac OS X, iPhoneOS,
+# or iPhoneSimulator SDK root directory.
+#
+# Usage: sysroot_path [--iphoneos | --iphonesimulator]
+
+SDK_TYPE=MacOSX
+if [ $# -gt 0 ]; then
+  case $1 in
+    --iphoneos ) SDK_TYPE=iPhoneOS ;;
+    --iphonesimulator ) SDK_TYPE=iPhoneSimulator ;;
+    * ) echo "usage: $0 [--iphoneos | --iphonesimulator]" && exit 1 ;;
+  esac
+fi
+
+if [[ "$OSTYPE" != "darwin"* ]]; then
+  OS_NAME=$(uname -s)
+  echo "Apple development tools not available on $OS_NAME."
+  exit 1
+fi
+
+XCODE_ROOT=$(xcode-select --print-path)
+
+if [ ! -d "${XCODE_ROOT}" ]; then
+  echo "Xcode is not installed."
+  exit 1
+fi
+
+# Try looking in the install directory for Xcode 4.x.
+PLATFORM_ROOT=${XCODE_ROOT}/Platforms/${SDK_TYPE}.platform
+if [ -d "${PLATFORM_ROOT}" ]; then
+  SDKS_ROOT=${PLATFORM_ROOT}/Developer/SDKs
+  if [ -d "${SDKS_ROOT}" ]; then
+    # Return the alphabetically last SDK in the directory, which should be the
+    # latest version.  This will need to be improved if iOS 10 ever releases.
+    SDK_PATH=$(ls -rd "${SDKS_ROOT}/${SDK_TYPE}"* | head -1)
+  fi
+fi
+
+if [ "x${SDK_PATH}" = "x" ]; then
+  # SDKs aren't in standard location, so ask xcodebuild to look up a common
+  # library, and then remove the library path.
+  if [ ${SDK_TYPE} == "iphoneos" ]; then
+    SDK_TYPE=iphoneos
+  elif [ ${SDK_TYPE} == "iphonesimulator" ]; then
+    SDK_TYPE=iphonesimulator
+  else
+    SDK_TYPE=macosx
+  fi
+
+  SDK_PATH=$(xcodebuild -sdk ${SDK_TYPE} -find-library system | sed 's/\/usr\/lib\/libsystem.dylib//')
+fi
+
+if [ "x${SDK_PATH}" = "x" ]; then
+  echo "No iOS SDKs located."
+  exit 1;
+fi
+echo ${SDK_PATH}
+exit 0


### PR DESCRIPTION
The task "j2objcLink" was added to the j2objc.gradle plugin. This
task allows the creation of static libraries/archives for linking against
iphone 32bit, iphone 64bit, and simulator i386 binaries.

Do the following to use the new task:

- Configure the j2objcConfig.compileFlags (i.e. "" for standard j2objc)

- Configure the j2objcConfig.distributionDir for output. This folder
  will contain include/ and lib/ with headers and universal lib.

- Optional configure j2objcConfig.staticLibName (i.e. "library.a")