### PR TITLE
Handle tests in the presence of prefixes

### DIFF
--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -209,7 +209,7 @@ class J2objcUtils {
                 newProps.load(new FileInputStream(proj.file(prefixesPath).path))
             } else {
                 // --prefix com.example.dir=CED
-                newProps.load(new StringReader(argValue));
+                newProps.load(new StringReader(argValue.trim()));
             }
             props.putAll(newProps)
         }


### PR DESCRIPTION
Multiple prefixes cause spaces in the argument values, which cause test failures since a test like "Prefix Class" instead of "PrefixClass" gets sent to the testrunner.