### PR TITLE
Make incremental compilation working

### DIFF
--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -521,11 +521,7 @@ class J2objcTranslateTask extends DefaultTask {
         def classPathArg = J2objcUtils.getClassPathArg(
                 project, project.j2objcConfig.translateClassPaths)
         
-        def javaClassPath = "${project.buildDir}/classes" 
-        if (classPathArg.size() > 0) {
-            javaClassPath += ":"
-        }
-        classPathArg = javaClassPath + classPathArg  
+        classPathArg += ":${project.buildDir}/classes"  
         
         // add java classpath base to classpath for incremental translation
         // we have to check if translation has been done before or not

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -457,7 +457,7 @@ class J2objcTranslateTask extends DefaultTask {
         FileCollection translatedSrcFiles = srcFiles - srcFilesChanged
         println "Unchanged files: "+translatedSrcFiles.getFiles().size()
        
-        
+        def translatedFiles = 0
         if (destDir.exists()) {
             FileCollection destFiles = project.files(project.fileTree(
                         dir: destDir, includes: ["**/*.h", "**/*.m"]))
@@ -469,6 +469,8 @@ class J2objcTranslateTask extends DefaultTask {
                     file.delete()
                 }
             }
+            // compute the number of translated files
+            translatedFiles = destFiles.getFiles().size()
         }
         
                
@@ -518,10 +520,25 @@ class J2objcTranslateTask extends DefaultTask {
      
         def classPathArg = J2objcUtils.getClassPathArg(
                 project, project.j2objcConfig.translateClassPaths)
-          
         
-        // TODO add translated .class files to classpath for incremental translation
-   
+        def javaClassPath = "${project.buildDir}/classes" 
+        if (classPathArg.size() > 0) {
+          javaClassPath += ":"
+        }
+        classPathArg = javaClassPath + classPathArg  
+        
+        // add java classpath base to classpath for incremental translation
+        // we have to check if translation has been done before or not
+        // if it is only an incremental build we must remove the --build-closure
+        // argument to make fewer translations of dependent classes 
+        // NOTE: TODO there is one case which fails, when you have translated the code
+        // make an incremental change which refers to a not yet translated class from a 
+        // source lib. In this case due to not using --build-closure the dependent source 
+        // we not be translated, this can be fixed with a clean and fresh build
+        def j2obcArgs = "${project.j2objcConfig.translateFlags}"
+        if (translatedFiles > 0) {
+          j2obcArgs = j2obcArgs.toString().replaceFirst("--build-closure","").trim()
+        }
           
         try {
             project.exec {
@@ -535,7 +552,7 @@ class J2objcTranslateTask extends DefaultTask {
                     args "-classpath", classPathArg
                 }
                 
-                args "${project.j2objcConfig.translateFlags}".split()
+                args j2obcArgs.split()
 
                 srcFiles.each { file ->
                     args file.path

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -537,7 +537,7 @@ class J2objcTranslateTask extends DefaultTask {
         // we not be translated, this can be fixed with a clean and fresh build
         def translateFlags = "${project.j2objcConfig.translateFlags}"
         if (translatedFiles > 0) {
-          translateFlags = translateFlags.toString().replaceFirst("--build-closure","").trim()
+            translateFlags = translateFlags.toString().replaceFirst("--build-closure","").trim()
         }
           
         try {

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -523,7 +523,7 @@ class J2objcTranslateTask extends DefaultTask {
         
         def javaClassPath = "${project.buildDir}/classes" 
         if (classPathArg.size() > 0) {
-          javaClassPath += ":"
+            javaClassPath += ":"
         }
         classPathArg = javaClassPath + classPathArg  
         

--- a/j2objc.gradle
+++ b/j2objc.gradle
@@ -535,9 +535,9 @@ class J2objcTranslateTask extends DefaultTask {
         // make an incremental change which refers to a not yet translated class from a 
         // source lib. In this case due to not using --build-closure the dependent source 
         // we not be translated, this can be fixed with a clean and fresh build
-        def j2obcArgs = "${project.j2objcConfig.translateFlags}"
+        def translateFlags = "${project.j2objcConfig.translateFlags}"
         if (translatedFiles > 0) {
-          j2obcArgs = j2obcArgs.toString().replaceFirst("--build-closure","").trim()
+          translateFlags = translateFlags.toString().replaceFirst("--build-closure","").trim()
         }
           
         try {
@@ -552,7 +552,7 @@ class J2objcTranslateTask extends DefaultTask {
                     args "-classpath", classPathArg
                 }
                 
-                args j2obcArgs.split()
+                args translateFlags.split()
 
                 srcFiles.each { file ->
                     args file.path


### PR DESCRIPTION
        // add java classpath base to classpath for incremental translation
        // we have to check if translation has been done before or not
        // if it is only an incremental build we must remove the --build-closure
        // argument to make fewer translations of dependent classes 
        // NOTE: TODO there is one case which fails, when you have translated the code
        // make an incremental change which refers to a not yet translated class from a 
        // source lib. In this case due to not using --build-closure the dependent source 
        // we not be translated, this can be fixed with a clean and fresh build